### PR TITLE
Fix wrong behaviour if the last iteration provide valid data

### DIFF
--- a/src/SparkFunHTU21D.cpp
+++ b/src/SparkFunHTU21D.cpp
@@ -55,17 +55,17 @@ uint16_t HTU21D::readValue(byte cmd)
   _i2cPort->endTransmission();
   
   //Hang out while measurement is taken. datasheet says 50ms, practice may call for more
-  byte toRead;
+  bool validResult;
   byte counter;
-  for (counter = 0, toRead = 0 ; counter < MAX_COUNTER && toRead != 3 ; counter++)
+  for (counter = 0, validResult = 0 ; counter < MAX_COUNTER && !validResult ; counter++)
   {
     delay(DELAY_INTERVAL);
 
     //Comes back in three bytes, data(MSB) / data(LSB) / Checksum
-    toRead = _i2cPort->requestFrom(HTU21D_ADDRESS, 3);
+    validResult = (3 == _i2cPort->requestFrom(HTU21D_ADDRESS, 3));
   }
 
-  if (counter == MAX_COUNTER) return (ERROR_I2C_TIMEOUT); //Error out
+  if (!validResult) return (ERROR_I2C_TIMEOUT); //Error out
 
   byte msb, lsb, checksum;
   msb = _i2cPort->read();


### PR DESCRIPTION
The last read in the for loop of the readValue method is always
interpreted as ERROR_I2C_TIMEOUT even valid data are available.

This is easy testable if the constant DELAY_INTERVAL will set to 100.
In this case only one iteration of the loop will performed. Without
this fix the method readValue will always return ERROR_I2C_TIMEOUT.
With this fix the behaviour depends of the availability of the data.